### PR TITLE
Multiple code improvements - common-java:DuplicatedBlocks, squid:S1444, squid:S1192, squid:ClassVariableVisibilityCheck, squid:S2864, squid:S3008

### DIFF
--- a/app/src/main/java/com/greysonparrelli/permisodemo/MainActivity.java
+++ b/app/src/main/java/com/greysonparrelli/permisodemo/MainActivity.java
@@ -66,17 +66,17 @@ public class MainActivity extends PermisoActivity {
             @Override
             public void onPermissionResult(Permiso.ResultSet resultSet) {
                 if (resultSet.isPermissionGranted(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-                    Toast.makeText(MainActivity.this, "Permission Granted!", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(MainActivity.this, R.string.permission_granted, Toast.LENGTH_SHORT).show();
                 } else if (resultSet.isPermissionPermanentlyDenied(Manifest.permission.WRITE_EXTERNAL_STORAGE)){
-                    Toast.makeText(MainActivity.this, "Permission Permanently Denied.", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(MainActivity.this, R.string.permission_permanently_denied, Toast.LENGTH_SHORT).show();
                 } else {
-                    Toast.makeText(MainActivity.this, "Permission Denied.", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(MainActivity.this, R.string.permission_denied, Toast.LENGTH_SHORT).show();
                 }
             }
 
             @Override
             public void onRationaleRequested(Permiso.IOnRationaleProvided callback, String... permissions) {
-                Permiso.getInstance().showRationaleInDialog("Permission Rationale", "Needed for demo purposes.", null, callback);
+                Permiso.getInstance().showRationaleInDialog(getString(R.string.permission_rationale), getString(R.string.needed_for_demo_purposes), null, callback);
             }
         }, Manifest.permission.WRITE_EXTERNAL_STORAGE);
     }
@@ -96,12 +96,12 @@ public class MainActivity extends PermisoActivity {
                 if (resultSet.isPermissionGranted(Manifest.permission.READ_CALENDAR)) {
                     numGranted++;
                 }
-                Toast.makeText(MainActivity.this, numGranted + "/2 Permissions Granted.", Toast.LENGTH_SHORT).show();
+                Toast.makeText(MainActivity.this, numGranted + R.string.two_permission_granted, Toast.LENGTH_SHORT).show();
             }
 
             @Override
             public void onRationaleRequested(Permiso.IOnRationaleProvided callback, String... permissions) {
-                Permiso.getInstance().showRationaleInDialog("Permission Rationale", "Needed for demo purposes.", null, callback);
+                Permiso.getInstance().showRationaleInDialog(getString(R.string.permission_rationale), getString(R.string.needed_for_demo_purposes), null, callback);
             }
         }, Manifest.permission.READ_CONTACTS, Manifest.permission.READ_CALENDAR);
     }
@@ -112,36 +112,26 @@ public class MainActivity extends PermisoActivity {
      */
     private void onDuplicateClick() {
         // First request
-        Permiso.getInstance().requestPermissions(new Permiso.IOnPermissionResult() {
-            @Override
-            public void onPermissionResult(Permiso.ResultSet resultSet) {
-                if (resultSet.areAllPermissionsGranted()) {
-                    Toast.makeText(MainActivity.this, "Permission Granted! (1)", Toast.LENGTH_SHORT).show();
-                } else {
-                    Toast.makeText(MainActivity.this, "Permission Denied. (1)", Toast.LENGTH_SHORT).show();
-                }
-            }
-
-            @Override
-            public void onRationaleRequested(Permiso.IOnRationaleProvided callback, String... permissions) {
-                Permiso.getInstance().showRationaleInDialog("Permission Rationale", "Needed for demo purposes.", null, callback);
-            }
-        }, Manifest.permission.CAMERA);
+        requestPermissions("1");
 
         // Second request for the same permission
+        requestPermissions("2");
+    }
+
+    private void requestPermissions(final String requestNumber) {
         Permiso.getInstance().requestPermissions(new Permiso.IOnPermissionResult() {
             @Override
             public void onPermissionResult(Permiso.ResultSet resultSet) {
                 if (resultSet.areAllPermissionsGranted()) {
-                    Toast.makeText(MainActivity.this, "Permission Granted! (2)", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(MainActivity.this, R.string.permission_granted + " (" + requestNumber + ")", Toast.LENGTH_SHORT).show();
                 } else {
-                    Toast.makeText(MainActivity.this, "Permission Denied. (2)", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(MainActivity.this, R.string.permission_denied + " (" + requestNumber + ")", Toast.LENGTH_SHORT).show();
                 }
             }
 
             @Override
             public void onRationaleRequested(Permiso.IOnRationaleProvided callback, String... permissions) {
-                Permiso.getInstance().showRationaleInDialog("Permission Rationale", "Needed for demo purposes.", null, callback);
+                Permiso.getInstance().showRationaleInDialog(getString(R.string.permission_rationale), getString(R.string.needed_for_demo_purposes), null, callback);
             }
         }, Manifest.permission.CAMERA);
     }

--- a/app/src/main/java/com/greysonparrelli/permisodemo/NonPermisoActivity.java
+++ b/app/src/main/java/com/greysonparrelli/permisodemo/NonPermisoActivity.java
@@ -60,17 +60,17 @@ public class NonPermisoActivity extends AppCompatActivity {
             @Override
             public void onPermissionResult(Permiso.ResultSet resultSet) {
                 if (resultSet.isPermissionGranted(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-                    Toast.makeText(NonPermisoActivity.this, "Permission Granted!", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(NonPermisoActivity.this, R.string.permission_granted, Toast.LENGTH_SHORT).show();
                 } else if (resultSet.isPermissionPermanentlyDenied(Manifest.permission.WRITE_EXTERNAL_STORAGE)){
-                    Toast.makeText(NonPermisoActivity.this, "Permission Permanently Denied.", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(NonPermisoActivity.this, R.string.permission_permanently_denied, Toast.LENGTH_SHORT).show();
                 } else {
-                    Toast.makeText(NonPermisoActivity.this, "Permission Denied.", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(NonPermisoActivity.this, R.string.permission_denied, Toast.LENGTH_SHORT).show();
                 }
             }
 
             @Override
             public void onRationaleRequested(Permiso.IOnRationaleProvided callback, String... permissions) {
-                Permiso.getInstance().showRationaleInDialog("Permission Rationale", "Needed for demo purposes.", null, callback);
+                Permiso.getInstance().showRationaleInDialog(getString(R.string.permission_rationale), getString(R.string.needed_for_demo_purposes), null, callback);
             }
         }, Manifest.permission.WRITE_EXTERNAL_STORAGE);
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,10 @@
 <resources>
     <string name="app_name">Permiso Demo</string>
     <string name="action_settings">Settings</string>
+    <string name="permission_rationale">Permission Rationale</string>
+    <string name="needed_for_demo_purposes">Needed for demo purposes.</string>
+    <string name="permission_granted">Permission Granted!</string>
+    <string name="permission_permanently_denied">Permission Permanently Denied.</string>
+    <string name="permission_denied">Permission Denied.</string>
+    <string name="two_permission_granted">2 Permissions Granted.</string>
 </resources>

--- a/permiso/src/main/java/com/greysonparrelli/permiso/Permiso.java
+++ b/permiso/src/main/java/com/greysonparrelli/permiso/Permiso.java
@@ -389,10 +389,10 @@ public class Permiso {
 
         private String[] getUngrantedPermissions() {
             List<String> ungrantedList = new ArrayList<>(requestResults.size());
-            for (String permission : requestResults.keySet()) {
-                Result result = requestResults.get(permission);
+            for (Map.Entry<String, Result> requestResultsEntry : requestResults.entrySet()) {
+                Result result = requestResultsEntry.getValue();
                 if (result == Result.DENIED || result == Result.PERMANENTLY_DENIED) {
-                    ungrantedList.add(permission);
+                    ungrantedList.add(requestResultsEntry.getKey());
                 }
             }
             return ungrantedList.toArray(new String[ungrantedList.size()]);

--- a/permiso/src/main/java/com/greysonparrelli/permiso/PermisoDialogFragment.java
+++ b/permiso/src/main/java/com/greysonparrelli/permiso/PermisoDialogFragment.java
@@ -15,7 +15,7 @@ import android.support.v7.app.AlertDialog;
  */
 public class PermisoDialogFragment extends DialogFragment {
 
-    public static String TAG = "PermisoDialogFragment";
+    public static final String TAG = "PermisoDialogFragment";
 
     private static final String KEY_TITLE = "title";
     private static final String KEY_MESSAGE = "message";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
common-java:DuplicatedBlocks - Source files should not have any duplicated blocks.
squid:S1444 - "public static" fields should be constant.
squid:S1192 - String literals should not be duplicated.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
squid:S3008 - Static non-final field names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/common-java:DuplicatedBlocks
https://dev.eclipse.org/sonar/rules/show/squid:S1444
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:S2864
https://dev.eclipse.org/sonar/rules/show/squid:S3008
Please let me know if you have any questions.
George Kankava
